### PR TITLE
fixes & cleanup for Gissler et al. drag force

### DIFF
--- a/SPlisHSPlasH/Drag/DragForce_Gissler2017.cpp
+++ b/SPlisHSPlasH/Drag/DragForce_Gissler2017.cpp
@@ -21,27 +21,19 @@ DragForce_Gissler2017::~DragForce_Gissler2017(void)
 
 void DragForce_Gissler2017::step()
 {
-	const Real rho_a = 1.2041;
-	const Real sigma = 0.0724;
-	const Real mu_l = 0.00102;
-	const Real C_F = 1.0 / 3.0;
-	const Real C_k = 8.0;
-	const Real C_d = 5.0;
-	const Real C_b = 0.5;
-	const Real mu_a = 0.00001845;
-
 	const Real supportRadius = m_model->getSupportRadius();
 	const Real radius = m_model->getParticleRadius();
 	const Real diam = 2.0*radius;
 	static const Real pi = static_cast<Real>(M_PI);
 	const Real rho_l = m_model->getDensity0();
 
+	// Air velocity.
 	const Vector3r va(0, 0, 0);
 
-	const Real L = cbrt(0.75/pi) * diam;
+	const Real L = cbrt(0.75 / pi) * diam;
 
 	const Real inv_td = 0.5*C_d * mu_l / (rho_l * L*L);
-	const Real td = 1.0/inv_td;
+	const Real td = 1.0 / inv_td;
 	Real omegaSquare = C_k * sigma / (rho_l * L*L*L) - inv_td*inv_td;
 	std::max(omegaSquare, 0.0);
 	const Real omega = sqrt(omegaSquare);
@@ -72,14 +64,16 @@ void DragForce_Gissler2017::step()
 		for (int i = 0; i < (int)numParticles; i++)
 		{
 			const Vector3r &vi = m_model->getVelocity(0, i);
-			Vector3r v_i_rel = vi - va;
+			Vector3r v_i_rel = va - vi;
 			const Real vi_rel_square = v_i_rel.squaredNorm();
 			const Real vi_rel_norm = sqrt(vi_rel_square);
 			const Real We_i = We_i_wo_v * vi_rel_square;
 
 			Vector3r v_i_rel_n = v_i_rel;
-			if (vi_rel_norm > 1.0e-6)
-				v_i_rel_n = v_i_rel_n * (1.0 / vi_rel_norm);
+			if (vi_rel_norm <= 1.0e-6)
+				continue;
+			// Else.
+			v_i_rel_n = v_i_rel_n * (1.0 / vi_rel_norm);
  
 			// Equation (8)
 			const Real y_i_max = std::min(vi_rel_square * y_coeff, 1.0);
@@ -129,14 +123,14 @@ void DragForce_Gissler2017::step()
 				max_v_x = std::max(max_v_x, x_v);
 			}
 			// Equation (15)
-			const Real w_i = 1.0 - max_v_x;
+			const Real w_i = std::max(0.0, std::min(1.0, 1.0 - max_v_x));
 
 			// Equation (14)
 			const Real A_i = w_i * A_i_unoccluded;
 
-			// drag force (negative since v_i_rel = vi - va)
+			// Drag force. Additionally dividing by mass to get acceleration.
 			Vector3r &ai = m_model->getAcceleration(i);
-			ai -= m_dragCoefficient * static_cast<Real>(0.5) / m_model->getMass(i) * rho_a * (v_i_rel * vi_rel_norm) * C_Di * A_i;
+			ai += m_dragCoefficient * static_cast<Real>(0.5) / m_model->getMass(i) * rho_a * (v_i_rel * vi_rel_norm) * C_Di * A_i;
 		}
 	}
 }

--- a/bin/DragTest.bat
+++ b/bin/DragTest.bat
@@ -1,0 +1,2 @@
+.\StaticBoundaryDemo.exe ../data/scenes/DragTest.json
+pause

--- a/data/Scenes/DragTest.json
+++ b/data/Scenes/DragTest.json
@@ -1,0 +1,24 @@
+{
+	"Configuration":
+	{
+		"timeStepSize": 0.001,
+		"particleRadius": 0.025,
+		"maxEmitterParticles": 5000,
+		"viscosity": 0.05,
+		"dragMethod": 2,
+		"dragCoefficient": 1.0,
+		"numberOfStepsPerRenderUpdate": 2,
+		"emitterReuseParticles": true,
+		"emitterBoxMin": [-2.0,-2.5,-2.0],
+		"emitterBoxMax": [1.0,4,2.0]
+	},
+    "FluidBlocks": [
+        {
+            "denseMode": 0,
+            "start": [-0.5, 0.0, -0.5],
+            "end": [0.5, 1.0, 0.5],
+            "translation": [0.0, 3.0, 0.0],
+            "scale": [1, 1, 1]
+        }
+    ]
+}


### PR DESCRIPTION
Main issue is that `vi - va` is computed instead of `va - vi` which then also leads to a wrong weighting computation.