### PR TITLE
Remove CMakeLists.txt file from project sources lists.

### DIFF
--- a/Demos/DynamicBoundaryDemo/CMakeLists.txt
+++ b/Demos/DynamicBoundaryDemo/CMakeLists.txt
@@ -76,8 +76,6 @@ add_executable(DynamicBoundaryDemo
 
 	${PBDWRAPPER_SOURCE_FILES}
 	${PBDWRAPPER_HEADER_FILES}
-  
-	CMakeLists.txt
 )
 
 if(DL_OUTPUT)

--- a/Demos/StaticBoundaryDemo/CMakeLists.txt
+++ b/Demos/StaticBoundaryDemo/CMakeLists.txt
@@ -44,8 +44,6 @@ add_executable(StaticBoundaryDemo
 	${PROJECT_PATH}/Demos/Common/TweakBarParameters.h
   
 	${VIS_FILES}          
-  
-	CMakeLists.txt
 )
 
 if(DL_OUTPUT)

--- a/SPlisHSPlasH/CMakeLists.txt
+++ b/SPlisHSPlasH/CMakeLists.txt
@@ -199,8 +199,6 @@ add_library(SPlisHSPlasH
 
 	${UTILS_HEADER_FILES}
 	${UTILS_SOURCE_FILES}
-	
-	CMakeLists.txt
 )
 
 add_dependencies(SPlisHSPlasH ExternalProject_CompactNSearch)

--- a/Tools/PartioViewer/CMakeLists.txt
+++ b/Tools/PartioViewer/CMakeLists.txt
@@ -23,8 +23,6 @@ add_executable(PartioViewer
 	main.cpp
 	
 	${VIS_FILES}
-
-	CMakeLists.txt
 )
 
 add_definitions(-DTW_NO_LIB_PRAGMA -DTW_STATIC)

--- a/Tools/SurfaceSampling/CMakeLists.txt
+++ b/Tools/SurfaceSampling/CMakeLists.txt
@@ -3,8 +3,6 @@ include_directories( ${EIGEN3_INCLUDE_DIR} )
 
 add_executable(SurfaceSampling
 	main.cpp
-
-	CMakeLists.txt
 )
 
 set_target_properties(SurfaceSampling PROPERTIES DEBUG_POSTFIX ${CMAKE_DEBUG_POSTFIX})

--- a/Tools/VolumeSampling/CMakeLists.txt
+++ b/Tools/VolumeSampling/CMakeLists.txt
@@ -5,8 +5,6 @@ add_executable(VolumeSampling
 	main.cpp
 	WindingNumbers.cpp
 	WindingNumbers.h
-	
-	CMakeLists.txt
 )
 
 set_target_properties(VolumeSampling PROPERTIES DEBUG_POSTFIX ${CMAKE_DEBUG_POSTFIX})

--- a/Utilities/CMakeLists.txt
+++ b/Utilities/CMakeLists.txt
@@ -26,8 +26,6 @@ add_library(Utilities
 	SystemInfo.h
 	Timing.h
 	Version.h
-	
-	CMakeLists.txt
 )
 
 add_dependencies(Utilities partio)

--- a/extern/freeglut/src/CMakeLists.txt
+++ b/extern/freeglut/src/CMakeLists.txt
@@ -55,8 +55,6 @@ add_library(freeglut SHARED
 	../include/GL/freeglut_ext.h
 	../include/GL/freeglut_std.h
 	../include/GL/glut.h
-	  
-	CMakeLists.txt
 )
 
 add_definitions(-DFREEGLUT_EXPORTS)         


### PR DESCRIPTION
Including CMakeLists.txt in the source list with recent versions of CMake breaks Visual Studio projects. As of about 7 months ago, CMakeLists.txt is added automatically by the generator. Without removing the manual additions, this causes incorrect Visual Studio project files to be generated that will not load in the IDE.

See https://gitlab.kitware.com/cmake/cmake/issues/17828 for details.