### PR TITLE
remove support radius from equation

### DIFF
--- a/SPlisHSPlasH/SurfaceTension/SurfaceTension_Akinci2013.cpp
+++ b/SPlisHSPlasH/SurfaceTension/SurfaceTension_Akinci2013.cpp
@@ -96,7 +96,7 @@ void SurfaceTension_Akinci2013::step()
 
 				// Curvature
 				const Vector3r &nj = getNormal(neighborIndex);
-				accel -= k * supportRadius* (ni - nj);
+				accel -= k * (ni - nj);
 
 				ai += K_ij * accel;
 			)


### PR DESCRIPTION
Dear Developers,

Following the equations, we (Fernando Zorilla and I)  found the computation of the surface tension for the Akinci2013 is not correct. The support radius should not be present in the summed up **accel** term.

When comparing the results in zero gravity and no boundaries, the fluid should converge to a spherical blob, which is the case after the adjustment.

Please check, to improve the code. 

Here a result compare screenshot at T ~= 5:
![AkinciSurfaceFix](https://user-images.githubusercontent.com/17740998/65601192-ec60b400-dfa1-11e9-8c06-39a29885da0c.JPG)
and the test scene file:
[NoGrav.zip](https://github.com/InteractiveComputerGraphics/SPlisHSPlasH/files/3652450/NoGrav.zip)
