### PR TITLE
Fixed Cmake Error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -141,5 +141,5 @@ setup(
 				(emitter_boundary_dest, [s for s in emitter_boundary if os.path.isfile(s)]),
 				(fonts_dest, [f for f in fonts if os.path.isfile(f)])],
     zip_safe=False,
-    install_requires=['numpy']
+    install_requires=['numpy' , 'cmake']
 )


### PR DESCRIPTION
Error message before fix :
```
(sps) C:\Users\yoonyoung\workspace\SPlisHSPlasH>pip install .
Processing c:\users\yoonyoung\workspace\splishsplash
  Preparing metadata (setup.py) ... done
Requirement already satisfied: numpy in c:\users\yoonyoung\anaconda3\envs\sps\lib\site-packages (from pySPlisHSPlasH==2.12.0) (1.21.6)
Building wheels for collected packages: pySPlisHSPlasH
  Building wheel for pySPlisHSPlasH (setup.py) ... error
  error: subprocess-exited-with-error

  × python setup.py bdist_wheel did not run successfully.
  │ exit code: 1
  ╰─> [55 lines of output]
      running bdist_wheel
      running build
      running build_py
      running build_ext
      Traceback (most recent call last):
        File "C:\Users\yoonyoung\workspace\SPlisHSPlasH\setup.py", line 36, in run
          out = subprocess.check_output(['cmake', '--version'])
        File "C:\Users\yoonyoung\anaconda3\envs\sps\lib\subprocess.py", line 411, in check_output
          **kwargs).stdout
        File "C:\Users\yoonyoung\anaconda3\envs\sps\lib\subprocess.py", line 488, in run
          with Popen(*popenargs, **kwargs) as process:
        File "C:\Users\yoonyoung\anaconda3\envs\sps\lib\subprocess.py", line 800, in __init__
          restore_signals, start_new_session)
        File "C:\Users\yoonyoung\anaconda3\envs\sps\lib\subprocess.py", line 1207, in _execute_child
          startupinfo)
      FileNotFoundError: [WinError 2] 지정된 파일을 찾을 수 없습니다

      During handling of the above exception, another exception occurred:

      Traceback (most recent call last):
        File "<string>", line 36, in <module>
        File "<pip-setuptools-caller>", line 34, in <module>
        File "C:\Users\yoonyoung\workspace\SPlisHSPlasH\setup.py", line 144, in <module>
          install_requires=['numpy']
        File "C:\Users\yoonyoung\anaconda3\envs\sps\lib\site-packages\setuptools\__init__.py", line 87, in setup
          return distutils.core.setup(**attrs)
        File "C:\Users\yoonyoung\anaconda3\envs\sps\lib\site-packages\setuptools\_distutils\core.py", line 185, in setup
          return run_commands(dist)
        File "C:\Users\yoonyoung\anaconda3\envs\sps\lib\site-packages\setuptools\_distutils\core.py", line 201, in run_commands
          dist.run_commands()
        File "C:\Users\yoonyoung\anaconda3\envs\sps\lib\site-packages\setuptools\_distutils\dist.py", line 969, in run_commands
          self.run_command(cmd)
        File "C:\Users\yoonyoung\anaconda3\envs\sps\lib\site-packages\setuptools\dist.py", line 1208, in run_command
          super().run_command(command)
        File "C:\Users\yoonyoung\anaconda3\envs\sps\lib\site-packages\setuptools\_distutils\dist.py", line 988, in run_command
          cmd_obj.run()
        File "C:\Users\yoonyoung\anaconda3\envs\sps\lib\site-packages\wheel\bdist_wheel.py", line 299, in run
          self.run_command('build')
        File "C:\Users\yoonyoung\anaconda3\envs\sps\lib\site-packages\setuptools\_distutils\cmd.py", line 318, in run_command
          self.distribution.run_command(command)
        File "C:\Users\yoonyoung\anaconda3\envs\sps\lib\site-packages\setuptools\dist.py", line 1208, in run_command
          super().run_command(command)
        File "C:\Users\yoonyoung\anaconda3\envs\sps\lib\site-packages\setuptools\_distutils\dist.py", line 988, in run_command
          cmd_obj.run()
        File "C:\Users\yoonyoung\anaconda3\envs\sps\lib\site-packages\setuptools\_distutils\command\build.py", line 132, in run
          self.run_command(cmd_name)
        File "C:\Users\yoonyoung\anaconda3\envs\sps\lib\site-packages\setuptools\_distutils\cmd.py", line 318, in run_command
          self.distribution.run_command(command)
        File "C:\Users\yoonyoung\anaconda3\envs\sps\lib\site-packages\setuptools\dist.py", line 1208, in run_command
          super().run_command(command)
        File "C:\Users\yoonyoung\anaconda3\envs\sps\lib\site-packages\setuptools\_distutils\dist.py", line 988, in run_command
          cmd_obj.run()
        File "C:\Users\yoonyoung\workspace\SPlisHSPlasH\setup.py", line 39, in run
          ", ".join(e.name for e in self.extensions))
      RuntimeError: CMake must be installed to build the following extensions: pySPlisHSPlasH
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
  ERROR: Failed building wheel for pySPlisHSPlasH
  Running setup.py clean for pySPlisHSPlasH
Failed to build pySPlisHSPlasH
Installing collected packages: pySPlisHSPlasH
  Running setup.py install for pySPlisHSPlasH ... error
  error: subprocess-exited-with-error

  × Running setup.py install for pySPlisHSPlasH did not run successfully.
  │ exit code: 1
  ╰─> [66 lines of output]
      running install
      C:\Users\yoonyoung\anaconda3\envs\sps\lib\site-packages\setuptools\command\install.py:37: SetuptoolsDeprecationWarning: setup.py install is deprecated. Use build and pip and other standards-based tools.
        setuptools.SetuptoolsDeprecationWarning,
      running build
      running build_py
      creating build
      creating build\lib.win-amd64-cpython-37
      creating build\lib.win-amd64-cpython-37\pySPlisHSPlasH
      copying pySPlisHSPlasH\__init__.py -> build\lib.win-amd64-cpython-37\pySPlisHSPlasH
      creating build\lib.win-amd64-cpython-37\pySPlisHSPlasH\scripts
      copying pySPlisHSPlasH\scripts\simulator.py -> build\lib.win-amd64-cpython-37\pySPlisHSPlasH\scripts
      copying pySPlisHSPlasH\scripts\__init__.py -> build\lib.win-amd64-cpython-37\pySPlisHSPlasH\scripts
      running build_ext
      Traceback (most recent call last):
        File "C:\Users\yoonyoung\workspace\SPlisHSPlasH\setup.py", line 36, in run
          out = subprocess.check_output(['cmake', '--version'])
        File "C:\Users\yoonyoung\anaconda3\envs\sps\lib\subprocess.py", line 411, in check_output
          **kwargs).stdout
        File "C:\Users\yoonyoung\anaconda3\envs\sps\lib\subprocess.py", line 488, in run
          with Popen(*popenargs, **kwargs) as process:
        File "C:\Users\yoonyoung\anaconda3\envs\sps\lib\subprocess.py", line 800, in __init__
          restore_signals, start_new_session)
        File "C:\Users\yoonyoung\anaconda3\envs\sps\lib\subprocess.py", line 1207, in _execute_child
          startupinfo)
      FileNotFoundError: [WinError 2] 지정된 파일을 찾을 수 없습니다

      During handling of the above exception, another exception occurred:

      Traceback (most recent call last):
        File "<string>", line 36, in <module>
        File "<pip-setuptools-caller>", line 34, in <module>
        File "C:\Users\yoonyoung\workspace\SPlisHSPlasH\setup.py", line 144, in <module>
          install_requires=['numpy']
        File "C:\Users\yoonyoung\anaconda3\envs\sps\lib\site-packages\setuptools\__init__.py", line 87, in setup
          return distutils.core.setup(**attrs)
        File "C:\Users\yoonyoung\anaconda3\envs\sps\lib\site-packages\setuptools\_distutils\core.py", line 185, in setup
          return run_commands(dist)
        File "C:\Users\yoonyoung\anaconda3\envs\sps\lib\site-packages\setuptools\_distutils\core.py", line 201, in run_commands
          dist.run_commands()
        File "C:\Users\yoonyoung\anaconda3\envs\sps\lib\site-packages\setuptools\_distutils\dist.py", line 969, in run_commands
          self.run_command(cmd)
        File "C:\Users\yoonyoung\anaconda3\envs\sps\lib\site-packages\setuptools\dist.py", line 1208, in run_command
          super().run_command(command)
        File "C:\Users\yoonyoung\anaconda3\envs\sps\lib\site-packages\setuptools\_distutils\dist.py", line 988, in run_command
          cmd_obj.run()
        File "C:\Users\yoonyoung\anaconda3\envs\sps\lib\site-packages\setuptools\command\install.py", line 68, in run
          return orig.install.run(self)
        File "C:\Users\yoonyoung\anaconda3\envs\sps\lib\site-packages\setuptools\_distutils\command\install.py", line 698, in run
          self.run_command('build')
        File "C:\Users\yoonyoung\anaconda3\envs\sps\lib\site-packages\setuptools\_distutils\cmd.py", line 318, in run_command
          self.distribution.run_command(command)
        File "C:\Users\yoonyoung\anaconda3\envs\sps\lib\site-packages\setuptools\dist.py", line 1208, in run_command
          super().run_command(command)
        File "C:\Users\yoonyoung\anaconda3\envs\sps\lib\site-packages\setuptools\_distutils\dist.py", line 988, in run_command
          cmd_obj.run()
        File "C:\Users\yoonyoung\anaconda3\envs\sps\lib\site-packages\setuptools\_distutils\command\build.py", line 132, in run
          self.run_command(cmd_name)
        File "C:\Users\yoonyoung\anaconda3\envs\sps\lib\site-packages\setuptools\_distutils\cmd.py", line 318, in run_command
          self.distribution.run_command(command)
        File "C:\Users\yoonyoung\anaconda3\envs\sps\lib\site-packages\setuptools\dist.py", line 1208, in run_command
          super().run_command(command)
        File "C:\Users\yoonyoung\anaconda3\envs\sps\lib\site-packages\setuptools\_distutils\dist.py", line 988, in run_command
          cmd_obj.run()
        File "C:\Users\yoonyoung\workspace\SPlisHSPlasH\setup.py", line 39, in run
          ", ".join(e.name for e in self.extensions))
      RuntimeError: CMake must be installed to build the following extensions: pySPlisHSPlasH
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
error: legacy-install-failure

× Encountered error while trying to install package.
╰─> pySPlisHSPlasH

note: This is an issue with the package mentioned above, not pip.
hint: See above for output from the failure.
```

After : 

(sps) C:\Users\yoonyoung\workspace\SPlisHSPlasH>pip install .
Processing c:\users\yoonyoung\workspace\splishsplash
  Preparing metadata (setup.py) ... done
Requirement already satisfied: numpy in c:\users\yoonyoung\anaconda3\envs\sps\lib\site-packages (from pySPlisHSPlasH==2.12.0) (1.21.6)
Building wheels for collected packages: pySPlisHSPlasH
  Building wheel for pySPlisHSPlasH (setup.py) ... done
  Created wheel for pySPlisHSPlasH: filename=pySPlisHSPlasH-2.12.0-cp37-cp37m-win_amd64.whl size=3750533 sha256=bb3643bbbb5b23d124f7aa59594939f2f1d348f32bd753613f5684eee7913056
  Stored in directory: C:\Users\YOONYO~1\AppData\Local\Temp\pip-ephem-wheel-cache-8ec7totd\wheels\e1\fb\1c\135b258e198e153cb5754107aa0a72f400233c64b0207f03be
Successfully built pySPlisHSPlasH
Installing collected packages: pySPlisHSPlasH
Successfully installed pySPlisHSPlasH-2.12.0


