### PR TITLE
prevent NaN 2d samples by adding if condition

### DIFF
--- a/SPlisHSPlasH/Utilities/RegularSampling2D.cpp
+++ b/SPlisHSPlasH/Utilities/RegularSampling2D.cpp
@@ -65,7 +65,11 @@ void RegularSampling2D::sampleMesh(const Matrix3r& rotation, const Vector3r & tr
 			#pragma omp critical
 			{
 				for (unsigned sample = 0; sample < numSamples; sample++)
-					samples.emplace_back(v0 + static_cast<Real>(sample) / (numSamples - 1) * dir);
+				{
+					if(numSamples > 1)
+						samples.emplace_back(v0 + static_cast<Real>(sample) / (numSamples - 1) * dir);
+			
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Hi! In 2d simulations sometimes I encounter NaN samples (For example, use the `cylinder.obj` or `sphere.obj` in `data/models` to get a 2d circle), and after investigation, I find the reason is that sometimes the `cuts[1]` equals to `cuts[0]` in this part of the code of RegularSampling2D.cpp, which leads to `numSamples = 1`, making the ``(numSamples - 1)`` a zero denominator. 
```c++
const Vector3r & v0 = cuts[0];
const Vector3r dir = cuts[1] - v0;
const Real l = dir.norm();
// ceil for oversampling, +1 to get from end to end
const auto numSamples = static_cast<unsigned int>(std::ceil(l / maxDistance)) + 1u;
#pragma omp critical
{
for (unsigned sample = 0; sample < numSamples; sample++)
                                 samples.emplace_back(v0 + static_cast<Real>(sample) / (numSamples - 1) * dir);
}
```