### PR TITLE
Add safeguard to "build" directory creation, fixing #271

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -121,7 +121,8 @@ splishsplash_version = f.readline().strip()
 f.close() 
 
 # create build directory
-os.mkdir('build')
+if not os.path.isdir('build'):
+    os.mkdir('build')
 
 setup(
     name=name,


### PR DESCRIPTION
Since the code to create the "build" directory was added only recently, I assume there is good reason for it to be present. Therefore, instead of removing the command, this commit adds a safeguard such that the directory is only created if it not already exists. This fixes #271.