### PR TITLE
Add new method to website

### DIFF
--- a/_pages/features.markdown
+++ b/_pages/features.markdown
@@ -86,6 +86,7 @@ The SPlisHSPlasH library implements the surface tension methods of the following
 * Nadir Akinci, Gizem Akinci, and Matthias Teschner. Versatile surface tension and adhesion for SPH fluids. ACM Trans. Graph., 32(6):182:1–182:8, 2013. 
 * Xiaowei He, Huamin Wang, Fengjun Zhang, Hongan Wang, Guoping Wang, and Kun Zhou, "Robust simulation of sparsely sampled thin features in SPH-based free surface flows", ACM Transactions on Graphics, 34(1), 2014.
 * F. Zorilla, M. Ritter, J. Sappl, W. Rauch, M. Harders, "Accelerating  Surface Tension Calculation in SPH via Particle Classification and Monte Carlo Integration", Computers 9, 23, 2020.
+* Jeske, Stefan Rhys, Lukas Westhofen, Fabian Löschner, José Antonio Fernández-Fernández, and Jan Bender. “Implicit Surface Tension for SPH Fluid Simulation.” ACM Transactions on Graphics, November 7, 2023. https://doi.org/10.1145/3631936.
 
 ## Vorticity
 

--- a/_pages/features.markdown
+++ b/_pages/features.markdown
@@ -86,7 +86,7 @@ The SPlisHSPlasH library implements the surface tension methods of the following
 * Nadir Akinci, Gizem Akinci, and Matthias Teschner. Versatile surface tension and adhesion for SPH fluids. ACM Trans. Graph., 32(6):182:1–182:8, 2013. 
 * Xiaowei He, Huamin Wang, Fengjun Zhang, Hongan Wang, Guoping Wang, and Kun Zhou, "Robust simulation of sparsely sampled thin features in SPH-based free surface flows", ACM Transactions on Graphics, 34(1), 2014.
 * F. Zorilla, M. Ritter, J. Sappl, W. Rauch, M. Harders, "Accelerating  Surface Tension Calculation in SPH via Particle Classification and Monte Carlo Integration", Computers 9, 23, 2020.
-* Jeske, Stefan Rhys, Lukas Westhofen, Fabian Löschner, José Antonio Fernández-Fernández, and Jan Bender. “Implicit Surface Tension for SPH Fluid Simulation.” ACM Transactions on Graphics, 2023. https://doi.org/10.1145/3631936.
+* Jeske, Stefan Rhys, Lukas Westhofen, Fabian Löschner, José Antonio Fernández-Fernández, and Jan Bender. "Implicit Surface Tension for SPH Fluid Simulation." ACM Transactions on Graphics, 2023. https://doi.org/10.1145/3631936.
 
 ## Vorticity
 

--- a/_pages/features.markdown
+++ b/_pages/features.markdown
@@ -86,7 +86,7 @@ The SPlisHSPlasH library implements the surface tension methods of the following
 * Nadir Akinci, Gizem Akinci, and Matthias Teschner. Versatile surface tension and adhesion for SPH fluids. ACM Trans. Graph., 32(6):182:1–182:8, 2013. 
 * Xiaowei He, Huamin Wang, Fengjun Zhang, Hongan Wang, Guoping Wang, and Kun Zhou, "Robust simulation of sparsely sampled thin features in SPH-based free surface flows", ACM Transactions on Graphics, 34(1), 2014.
 * F. Zorilla, M. Ritter, J. Sappl, W. Rauch, M. Harders, "Accelerating  Surface Tension Calculation in SPH via Particle Classification and Monte Carlo Integration", Computers 9, 23, 2020.
-* Jeske, Stefan Rhys, Lukas Westhofen, Fabian Löschner, José Antonio Fernández-Fernández, and Jan Bender. “Implicit Surface Tension for SPH Fluid Simulation.” ACM Transactions on Graphics, November 7, 2023. https://doi.org/10.1145/3631936.
+* Jeske, Stefan Rhys, Lukas Westhofen, Fabian Löschner, José Antonio Fernández-Fernández, and Jan Bender. “Implicit Surface Tension for SPH Fluid Simulation.” ACM Transactions on Graphics, 2023. https://doi.org/10.1145/3631936.
 
 ## Vorticity
 

--- a/_pages/gallery.markdown
+++ b/_pages/gallery.markdown
@@ -89,11 +89,11 @@ The following videos were generated using the SPlisHSPlasH library (if you click
     </tr>
     <tr>
       <td style="text-align: center"><em>Fast Octree Neighborhood Search for SPH Simulations</em></td>
-      <td style="text-align: center"></td>
+      <td style="text-align: center"><em>Implicit Surface Tension for SPH Fluid Simulation</em></td>
     </tr>
     <tr>
       <td style="text-align: center"><a href="https://www.youtube.com/watch?v=3MYgOasyhnk"><img src="https://img.youtube.com/vi/3MYgOasyhnk/0.jpg" alt="Video" /></a></td>
-      <td style="text-align: center"></td>
+      <td style="text-align: center"><a href="https://www.youtube.com/watch?v=xWXTQJl4pZ0"><img src="https://img.youtube.com/vi/xWXTQJl4pZ0/0.jpg" alt="Video" /></a></td>
     </tr>
   </tbody>
 </table>

--- a/_pages/references.markdown
+++ b/_pages/references.markdown
@@ -52,7 +52,7 @@ SPlisHSPlasH implements the methods of the following publications:
 * Marcel Weiler, Dan Koschier, Magnus Brand and Jan Bender. A Physically Consistent Implicit Viscosity Solver for SPH Fluids. Computer Graphics Forum (Eurographics), 37(2), 2018
 * Lukas Westhofen, Stefan Rhys Jeske, Jan Bender. A comparison of linear consistent correction methods for first-order SPH derivatives. Proceedings of the ACM on Computer Graphics and Interactive Techniques (SCA), 2023
 * F. Zorilla, M. Ritter, J. Sappl, W. Rauch, M. Harders. Accelerating  Surface Tension Calculation in SPH via Particle Classification and Monte Carlo Integration. Computers 9, 23, 2020.
-* Jeske, Stefan Rhys, Lukas Westhofen, Fabian Löschner, José Antonio Fernández-Fernández, and Jan Bender. “Implicit Surface Tension for SPH Fluid Simulation.” ACM Transactions on Graphics, November 7, 2023. https://doi.org/10.1145/3631936.
+* Jeske, Stefan Rhys, Lukas Westhofen, Fabian Löschner, José Antonio Fernández-Fernández, and Jan Bender. Implicit Surface Tension for SPH Fluid Simulation. ACM Transactions on Graphics, 2023. https://doi.org/10.1145/3631936.
 
 
 ## Other research projects using SPlisHSPlasH

--- a/_pages/references.markdown
+++ b/_pages/references.markdown
@@ -52,6 +52,7 @@ SPlisHSPlasH implements the methods of the following publications:
 * Marcel Weiler, Dan Koschier, Magnus Brand and Jan Bender. A Physically Consistent Implicit Viscosity Solver for SPH Fluids. Computer Graphics Forum (Eurographics), 37(2), 2018
 * Lukas Westhofen, Stefan Rhys Jeske, Jan Bender. A comparison of linear consistent correction methods for first-order SPH derivatives. Proceedings of the ACM on Computer Graphics and Interactive Techniques (SCA), 2023
 * F. Zorilla, M. Ritter, J. Sappl, W. Rauch, M. Harders. Accelerating  Surface Tension Calculation in SPH via Particle Classification and Monte Carlo Integration. Computers 9, 23, 2020.
+* Jeske, Stefan Rhys, Lukas Westhofen, Fabian Löschner, José Antonio Fernández-Fernández, and Jan Bender. “Implicit Surface Tension for SPH Fluid Simulation.” ACM Transactions on Graphics, November 7, 2023. https://doi.org/10.1145/3631936.
 
 
 ## Other research projects using SPlisHSPlasH


### PR DESCRIPTION
Add our paper: 

Jeske, Stefan Rhys, Lukas Westhofen, Fabian Löschner, José Antonio Fernández-Fernández, and Jan Bender. “Implicit Surface Tension for SPH Fluid Simulation.” ACM Transactions on Graphics, November 7, 2023. https://doi.org/10.1145/3631936.

to the listed methods on the website.