### PR TITLE
Implement alternative (Blender style) camera controls

### DIFF
--- a/GUI/OpenGL/MiniGL.cpp
+++ b/GUI/OpenGL/MiniGL.cpp
@@ -71,6 +71,7 @@ std::vector<MiniGL::MouseMoveFct> MiniGL::m_mouseMoveFct;
 std::vector<MiniGL::MouseWheelFct> MiniGL::m_mouseWheelFct;
 GLFWwindow* MiniGL::m_glfw_window = nullptr;
 bool MiniGL::m_vsync = false;
+bool MiniGL::m_alt_camera = false;
 double MiniGL::m_lastTime;
 
 void MiniGL::bindTexture()
@@ -470,7 +471,7 @@ void MiniGL::setClientSceneFunc (SceneFct func)
 	scenefunc = func;
 }
 
-void MiniGL::init(const int width, const int height, const char *name, const bool vsync, const bool maximized)
+void MiniGL::init(const int width, const int height, const char *name, const bool vsync, const bool maximized, const bool alt_camera)
 {
 	fovy = 60;
 	znear = 0.5f;
@@ -479,6 +480,7 @@ void MiniGL::init(const int width, const int height, const char *name, const boo
 	m_width = width;
 	m_height = height;
 	m_vsync = vsync;
+	m_alt_camera = alt_camera;
 
 	scenefunc = nullptr;
 
@@ -833,6 +835,11 @@ void MiniGL::mouseWheel(GLFWwindow* window, double xoffset, double yoffset)
 			return;
 	}
 
+	if (m_alt_camera && yoffset != 0) {
+		// translate scene in z direction
+		move (0, 0, static_cast<Real>(yoffset) / static_cast<Real>(10.0));
+	}
+
 	if (yoffset > 0)
 		movespeed *= 2.0;
 	else
@@ -851,7 +858,7 @@ void MiniGL::mouseMove (GLFWwindow* window, double x, double y)
 	double d_x = mouse_pos_x_old - x;
 	double d_y = y - mouse_pos_y_old;
 
-	if (mouse_button == GLFW_MOUSE_BUTTON_1)
+	if ((!m_alt_camera && mouse_button == GLFW_MOUSE_BUTTON_1) || (m_alt_camera && mouse_button == GLFW_MOUSE_BUTTON_MIDDLE))
 	{
 		// translate scene in z direction		
 		if (modifier_key == GLFW_MOD_CONTROL)
@@ -864,7 +871,7 @@ void MiniGL::mouseMove (GLFWwindow* window, double x, double y)
 			move (-static_cast<Real>(d_x) / static_cast<Real>(20.0), -static_cast<Real>(d_y) / static_cast<Real>(20.0), 0);
 		}
 		// rotate scene around x, y axis
-		else if (modifier_key == GLFW_MOD_ALT)
+		else if (modifier_key == GLFW_MOD_ALT || m_alt_camera)
 		{
 			rotateX(static_cast<Real>(d_y)/ static_cast<Real>(100.0));
 			rotateY(-static_cast<Real>(d_x)/ static_cast<Real>(100.0));

--- a/GUI/OpenGL/MiniGL.h
+++ b/GUI/OpenGL/MiniGL.h
@@ -121,6 +121,7 @@ namespace SPH
 		static GLUquadricObj* m_sphereQuadric;
 		static GLFWwindow* m_glfw_window;
 		static bool m_vsync;
+		static bool m_alt_camera;
 		static double m_lastTime;
 
 		static void reshape (GLFWwindow* glfw_window, int w, int h);
@@ -158,7 +159,7 @@ namespace SPH
 		static void setClientDestroyFunc(DestroyFct func);
 		static void addKeyFunc(int key, int modifiers, std::function<void()> const& func);
 		static std::vector<KeyFunction> &getKeyFunc() { return keyfunc; }
-		static void init(const int width, const int height, const char* name, const bool vsync, const bool maximized = false);
+		static void init(const int width, const int height, const char* name, const bool vsync, const bool maximized = false, const bool alt_camera = false);
 		static void destroy ();
 		static void viewport ();
 		static void initLights ();
@@ -180,6 +181,8 @@ namespace SPH
 		static void rgbToHsv(float r, float g, float b, float *hsv);
 		static int getModifierKey() { return modifier_key; }
 		static bool getVSync() { return m_vsync; }
+		static void setAltCameraMode(const bool enabled) { m_alt_camera = enabled; }
+		static bool getAltCameraMode() { return m_alt_camera; }
 
 		static void addReshapeFunc(ReshapeFct func) { m_reshapeFct.push_back(func); }
 		static std::vector<ReshapeFct> &getReshapeFunc() { return m_reshapeFct; }

--- a/Simulator/GUI/imgui/Simulator_GUI_imgui.cpp
+++ b/Simulator/GUI/imgui/Simulator_GUI_imgui.cpp
@@ -28,6 +28,7 @@ Simulator_GUI_imgui::Simulator_GUI_imgui(SimulatorBase *base) :
 	m_currentFluidModel = 0;
 	m_currentScaleIndex = 0;
 	m_vsync = false;
+	m_alt_camera = false;
 	m_iniFound = false;
 	m_showLogWindow = true;
 }
@@ -62,7 +63,7 @@ void Simulator_GUI_imgui::init(const char *name)
 	io.ConfigFlags |= ImGuiConfigFlags_DockingEnable;           // Enable Docking
 	ImGui::LoadIniSettingsFromDisk(io.IniFilename);
 
-	MiniGL::init(1280, 960, name, m_userSettings.vsync, m_userSettings.maximized);
+	MiniGL::init(1280, 960, name, m_userSettings.vsync, m_userSettings.maximized, m_userSettings.alt_camera);
 	MiniGL::initLights();
 
 	const Utilities::SceneLoader::Scene& scene = SceneConfiguration::getCurrent()->getScene();
@@ -145,6 +146,7 @@ void Simulator_GUI_imgui::readIni(ImGuiContext* ctx, ImGuiSettingsHandler* handl
 	else if (sscanf(line, "scale=%d", &i) == 1) { settings->scaleIndex = i; }
 	else if (sscanf(line, "maximized=%d", &i) == 1) { settings->maximized = (i != 0); }
 	else if (sscanf(line, "vsync=%d", &i) == 1) { settings->vsync = (i != 0); }
+	else if (sscanf(line, "alt_camera=%d", &i) == 1) { settings->alt_camera = (i != 0); }
 	else if (sscanf(line, "show_log_window=%d", &i) == 1) { settings->show_log_window = (i != 0); }
 	else if (sscanf(line, "log_filter=%d", &i) == 1) { settings->log_filter = i; }
 }
@@ -166,6 +168,7 @@ void Simulator_GUI_imgui::writeIni(ImGuiContext* ctx, ImGuiSettingsHandler* hand
 	out_buf->appendf("maximized=%d\n", MiniGL::getWindowMaximized());
 
 	out_buf->appendf("vsync=%d\n", gui->m_vsync);
+	out_buf->appendf("alt_camera=%d\n", gui->m_alt_camera);
 	out_buf->appendf("show_log_window=%d\n", gui->m_showLogWindow);
 	out_buf->appendf("log_filter=%d\n", gui->m_logWindow->getSelectedFilter());
 }
@@ -176,6 +179,7 @@ void Simulator_GUI_imgui::applySettings(ImGuiContext* ctx, ImGuiSettingsHandler*
 	UserSettings* settings = (UserSettings*) &gui->m_userSettings;
 	gui->m_currentScaleIndex = settings->scaleIndex;
 	gui->m_vsync = settings->vsync;
+	gui->m_alt_camera = settings->alt_camera;
 	gui->m_showLogWindow = settings->show_log_window;
 	gui->m_iniFound = true;
 	gui->m_logWindow->setSelectedFilter(settings->log_filter);
@@ -293,6 +297,11 @@ void Simulator_GUI_imgui::createMenuBar()
 			{
 				m_vsync = !m_vsync;
 				openpopup = true;
+			}
+			if (ImGui::MenuItem("Alternative camera controls", "", m_alt_camera))
+			{
+				m_alt_camera = !m_alt_camera;
+				MiniGL::setAltCameraMode(m_alt_camera);
 			}
 			if (ImGui::MenuItem("Scale - 100%", "", m_currentScaleIndex == 0))
 			{

--- a/Simulator/GUI/imgui/Simulator_GUI_imgui.h
+++ b/Simulator/GUI/imgui/Simulator_GUI_imgui.h
@@ -18,11 +18,12 @@ namespace SPH
 		int win_x, win_y;
 		int win_width, win_height;
 		bool vsync;
+		bool alt_camera;
 		bool show_log_window;
 		bool maximized;
 		int log_filter;
 
-		UserSettings() { win_x = 0; win_y = 0; win_width = 1280; win_height = 960; scaleIndex = 0; vsync = false; maximized = false; log_filter = 1; }
+		UserSettings() { win_x = 0; win_y = 0; win_width = 1280; win_height = 960; scaleIndex = 0; vsync = false; alt_camera = false; maximized = false; log_filter = 1; }
 	};
 
 	class LogWindow;
@@ -43,6 +44,7 @@ namespace SPH
 			std::vector<float> m_scales;
 			unsigned int m_currentScaleIndex;
 			bool m_vsync;
+			bool m_alt_camera;
 			bool m_showLogWindow;
 			ImGuiContext* m_context;
 			UserSettings m_userSettings;


### PR DESCRIPTION
This PR implements alternative camera controls for the GUI that corresponds to typical Blender camera controls:
- Middle mouse button + drag: rotate camera
- Middle mouse button + shift key: move camera
- Middle mouse button + ctrl: zoom
- Mouse wheel: zoom

This alternative mode is disabled by default, can be activated from the GUI menu and will be stored in the settings file:
![image](https://github.com/user-attachments/assets/9d89f76b-6141-481f-9dcd-d20233f758e7)
