### PR TITLE
New emitter concept for variable velocity and velocity profiles

### DIFF
--- a/SPlisHSPlasH/Emitter.cpp
+++ b/SPlisHSPlasH/Emitter.cpp
@@ -10,9 +10,10 @@
 using namespace SPH;
 
 Emitter::Emitter(FluidModel* model, const unsigned int width, const unsigned int height, const Vector3r& pos,
-                 const Matrix3r& rotation, const Real velocity, const unsigned int type, const bool useBoundary)
+                 const Matrix3r& rotation, const Real velocity, const unsigned int type, const bool useBoundary,
+                 const unsigned int velocityProfile)
     : m_model(model), m_width(width), m_x(pos), m_rotation(rotation), m_velocity(velocity), m_type(type),
-      m_useBoundary(useBoundary)
+      m_useBoundary(useBoundary), m_velocityProfile(velocityProfile)
 {
     Simulation* sim = Simulation::getCurrent();
     m_depth = getDepth();
@@ -101,7 +102,7 @@ void Emitter::emitParticles(std::vector<unsigned int>& reusedParticles, unsigned
     const Vector3r axisDepth = m_rotation.col(0);
     const Vector3r axisHeight = m_rotation.col(1);
     const Vector3r axisWidth = m_rotation.col(2);
-    Vector3r emitVel = m_velocity * axisDepth;
+    Vector3r bulkEmitVel = m_velocity * axisDepth;
     Simulation* sim = Simulation::getCurrent();
     const Real particleRadius = sim->getParticleRadius();
     const Real particleDiameter = static_cast<Real>(2.0) * particleRadius;
@@ -128,7 +129,6 @@ void Emitter::emitParticles(std::vector<unsigned int>& reusedParticles, unsigned
                     {
                         m_model->setPosition(indexNextNewParticle, spawnPos);
                         m_model->setParticleState(indexNextNewParticle, ParticleState::AnimatedByEmitter);
-                        m_model->setVelocity(indexNextNewParticle, emitVel);
                         m_model->setObjectId(indexNextNewParticle, m_objectId);
 
                         indexNextNewParticle++;
@@ -149,9 +149,24 @@ void Emitter::emitParticles(std::vector<unsigned int>& reusedParticles, unsigned
 
             if (insideEmitter) {
                 // Advect ALL particles inside the emitter.
-                // TODO: Doesn't get all particles within the boundary. Perhaps use getSizeExtraMargin()?
-                m_model->setPosition(i, tempPos + timeStepSize * emitVel);
-                m_model->setVelocity(i, emitVel);
+                //
+                // TODO: Doesn't get all particles within the rigid body. Perhaps use getSizeExtraMargin()?
+                Vector3r localEmitVel;
+                if (m_type == 1 && m_velocityProfile != 0) {
+                    // different velocity profiles for circular emitters
+                    const Vector3r localPos = tempPos - m_x;
+                    const Real r = sqrt(pow(axisWidth.dot(localPos), 2.0) + (pow(axisHeight.dot(localPos), 2.0)));
+                    const Vector3r maxEmitVel =
+                        (1.0 / (1.0 - (2.0 / (static_cast<Real>(m_velocityProfile) + 2.0)))) * bulkEmitVel;
+                    const Real relativeRadius = r / (m_size[1] / 2.0);
+                    localEmitVel = maxEmitVel * (1.0 - pow(relativeRadius, static_cast<Real>(m_velocityProfile)));
+                }
+                else {// box shaped emitter or uniform velocity profile
+                    localEmitVel = bulkEmitVel;
+                }
+
+                m_model->setPosition(i, tempPos + timeStepSize * localEmitVel);
+                m_model->setVelocity(i, localEmitVel);
             }
             if (!insideEmitter && m_model->getParticleState(i) == ParticleState::AnimatedByEmitter
                 && m_model->getObjectId(i) == m_objectId)
@@ -164,7 +179,7 @@ void Emitter::emitParticles(std::vector<unsigned int>& reusedParticles, unsigned
                     // reuse a particle
                     m_model->setPosition(reusedParticles[indexReuse], tempPos - axisDepth * particleDiameter * m_depth);
                     m_model->setParticleState(reusedParticles[indexReuse], ParticleState::AnimatedByEmitter);
-                    m_model->setVelocity(reusedParticles[indexReuse], emitVel);
+                    m_model->setVelocity(reusedParticles[indexReuse], bulkEmitVel);
                     m_model->setObjectId(reusedParticles[indexReuse], m_objectId);
                     indexReuse++;
                 }
@@ -172,7 +187,6 @@ void Emitter::emitParticles(std::vector<unsigned int>& reusedParticles, unsigned
                     // spawn a new particle
                     m_model->setPosition(indexNextNewParticle, tempPos - axisDepth * particleDiameter * m_depth);
                     m_model->setParticleState(indexNextNewParticle, ParticleState::AnimatedByEmitter);
-                    m_model->setVelocity(indexNextNewParticle, emitVel);
                     m_model->setObjectId(indexNextNewParticle, m_objectId);
 
                     indexNextNewParticle++;

--- a/SPlisHSPlasH/Emitter.cpp
+++ b/SPlisHSPlasH/Emitter.cpp
@@ -16,7 +16,6 @@ Emitter::Emitter(FluidModel* model, const unsigned int width, const unsigned int
       m_useBoundary(useBoundary), m_velocityProfile(velocityProfile)
 {
     Simulation* sim = Simulation::getCurrent();
-    m_depth = getDepth();
 
     if (m_type == 1) {
         // for cylindrical emitters, the height must not be smaller than the width, to spawn the initial particles.
@@ -33,20 +32,12 @@ Emitter::~Emitter(void) {}
 
 void Emitter::reset() { m_emitCounter = 0; }
 
-int Emitter::getDepth()
-{
-    // This is its own function to not repeat the calculation in the constructor but still have it available for the
-    // static getSize().
-    Simulation* sim = Simulation::getCurrent();
-    return static_cast<int>(std::ceil(sim->getSupportRadius() / sim->getParticleRadius()));
-}
-
 Vector3r Emitter::getSize(const Real width, const Real height, const int type)
 {
 
     const Simulation* sim = Simulation::getCurrent();
     const Real particleDiameter = 2 * sim->getParticleRadius();
-    const Real depth = static_cast<Real>(getDepth());
+    const Real depth = static_cast<Real>(m_depth);
     Vector3r size;
 
     // The emitter must be larger in emit direction, else particles may spawn just outside.

--- a/SPlisHSPlasH/Emitter.cpp
+++ b/SPlisHSPlasH/Emitter.cpp
@@ -1,401 +1,202 @@
 #include "Emitter.h"
+#include "FluidModel.h"
 #include "SPHKernels.h"
-#include <iostream>
+#include "Simulation.h"
 #include "TimeManager.h"
 #include "TimeStep.h"
-#include "FluidModel.h"
-#include "Simulation.h"
+#include "Utilities/Logger.h"
+#include <iostream>
 
 using namespace SPH;
 
-Emitter::Emitter(FluidModel *model,
-	const unsigned int width, const unsigned int height,
-	const Vector3r &pos, const Matrix3r & rotation,
-	const Real velocity,
-	const unsigned int type)
-	: m_model(model)
-	, m_width(width)
-	, m_height(height)
-	, m_x(pos)
-	, m_rotation(rotation)
-	, m_velocity(velocity)
-	, m_type(type)
-	, m_nextEmitTime(0)
-	, m_emitStartTime(0)
-	, m_emitEndTime(std::numeric_limits<Real>::max())
-	, m_emitCounter(0)
+Emitter::Emitter(FluidModel* model, const unsigned int width, const unsigned int height, const Vector3r& pos,
+                 const Matrix3r& rotation, const Real velocity, const unsigned int type, const bool useBoundary)
+    : m_model(model), m_width(width), m_x(pos), m_rotation(rotation), m_velocity(velocity), m_type(type),
+      m_useBoundary(useBoundary)
 {
+    Simulation* sim = Simulation::getCurrent();
+    m_depth = getDepth();
+
+    if (m_type == 1) {
+        // for cylindrical emitters, the height must not be smaller than the width, to spawn the initial particles.
+        m_height = width;
+    }
+    else {
+        m_height = height;
+    }
+
+    m_size = getSize(static_cast<Real>(m_width), static_cast<Real>(m_height), m_type);
 }
 
-Emitter::~Emitter(void)
-{
-}
+Emitter::~Emitter(void) {}
 
-void Emitter::reset()
+void Emitter::reset() { m_emitCounter = 0; }
+
+int Emitter::getDepth()
 {
-	m_nextEmitTime = m_emitStartTime;
-	m_emitCounter = 0;	
+    // This is its own function to not repeat the calculation in the constructor but still have it available for the
+    // static getSize().
+    Simulation* sim = Simulation::getCurrent();
+    return static_cast<int>(std::ceil(sim->getSupportRadius() / sim->getParticleRadius()));
 }
 
 Vector3r Emitter::getSize(const Real width, const Real height, const int type)
 {
-	Simulation *sim = Simulation::getCurrent();
-	const Real radius = sim->getParticleRadius();
-	const Real diam = static_cast<Real>(2.0)*radius;
 
-	const Real supportRadius = sim->getSupportRadius();
-	const Real animationMarginAround = diam;
-	Vector3r size;
-	if (type == 0)
-	{
-		if (sim->getBoundaryHandlingMethod() == BoundaryHandlingMethods::Akinci2012)
-		{
-			size = {
-				2 * supportRadius,
-				height * diam + 2 * animationMarginAround,
-				width * diam + 2 * animationMarginAround
-			};
-		}
-		else
-		{
-			size = {
-				static_cast<Real>(2.0)* supportRadius,
-				height * diam + static_cast<Real>(2.5) * animationMarginAround,
-				width * diam + static_cast<Real>(2.5) * animationMarginAround
-			};
-		}
-	}
-	else
-	{
-		if (sim->getBoundaryHandlingMethod() == BoundaryHandlingMethods::Akinci2012)
-		{
-			// height and radius of cylinder
-			const Real h = 2 * supportRadius;
-			const Real r = 0.5f * width * diam + animationMarginAround;
-			size = { h, 2 * r, 2 * r };
-		}
-		else
-		{
-			// height and radius of cylinder
-			const Real h = static_cast<Real>(2.25) * supportRadius;
-			const Real r = 0.5f * width * diam + animationMarginAround;
-			size = { h, static_cast<Real>(2.25) * r, static_cast<Real>(2.25) * r };
-		}
-	}
+    const Simulation* sim = Simulation::getCurrent();
+    const Real particleDiameter = 2 * sim->getParticleRadius();
+    const Real depth = static_cast<Real>(getDepth());
+    Vector3r size;
 
-	return size;
+    // The emitter must be larger in emit direction, else particles may spawn just outside.
+    if (type == 0) {
+        // box emitter
+        size = {depth + 1, height, width};
+    }
+    else if (type == 1) {
+        // cylindrical emitter
+        size = {depth + 1, width, width};
+    }
+
+    return size * particleDiameter;
 }
 
-void Emitter::emitParticles(std::vector <unsigned int> &reusedParticles, unsigned int &indexReuse, unsigned int &numEmittedParticles)
+Vector3r Emitter::getSizeExtraMargin(const Real width, const Real height, const int type)
 {
-	TimeManager *tm = TimeManager::getCurrent();
-	const Real t = tm->getTime();
-	const Real timeStepSize = tm->getTimeStepSize();
-	const Vector3r & emitDir = m_rotation.col(0);
-	Vector3r emitVel = m_velocity * emitDir;
-	Simulation *sim = Simulation::getCurrent();
-	const Real radius = sim->getParticleRadius();
-	const Real diam = static_cast<Real>(2.0)*radius;
+    // The box or cylinder around the emitter needs some padding.
+    const Simulation* sim = Simulation::getCurrent();
+    // const BoundaryHandlingMethods* boundaryMethod = sim->getBoundaryHandlingMethod();
+    Real extraMargin;
+    if (type == 0) {
+        // box emitter
+        if (sim->getBoundaryHandlingMethod() == BoundaryHandlingMethods::Akinci2012) {
+            extraMargin = static_cast<Real>(2.0);
+        }
+        else {
+            extraMargin = static_cast<Real>(2.5);
+        }
+    }
+    else if (type == 1) {
+        // cylindrical emitter
+        if (sim->getBoundaryHandlingMethod() == BoundaryHandlingMethods::Akinci2012) {
+            extraMargin = static_cast<Real>(2.0);
+        }
+        else {
+            extraMargin = static_cast<Real>(2.5);
+        }
+    }
+    else {
+        extraMargin = 0.0;
+    }
 
-	// shortly before the emitter starts, cleanup the emitter from particles
-	if (t < m_emitStartTime || t > m_emitEndTime)
- 		emitVel = emitDir * radius * 10 / 0.25;
-
-	if (t >= m_emitStartTime - 0.25 && t <= m_emitEndTime)
-	{
-		// animate emitted particles
-		const Vector3r & x0 = m_x;
-
-		const Real animationMarginAhead = sim->getSupportRadius();
-		const Vector3r size = getSize(static_cast<Real>(m_width), static_cast<Real>(m_height), m_type);
-		const Vector3r halfSize = 0.5 * size;
-		const Vector3r pos = x0 + static_cast<Real>(0.5) * animationMarginAhead * emitDir;
-
-		const unsigned int nModels = sim->numberOfFluidModels();
-		for (unsigned int m = 0; m < nModels; m++)
-		{
-			FluidModel *fm = sim->getFluidModel(m);
-			const unsigned int numParticles = fm->numActiveParticles();
-			#pragma omp parallel for schedule(static) default(shared)
-			for (int i = 0; i < (int)numParticles; i++)
-			{
-				Vector3r &xi = fm->getPosition(i);
-				if (inBox(xi, pos, m_rotation, halfSize))
-				{
-					fm->getVelocity(i) = emitVel;
-					fm->getPosition(i) += timeStepSize * emitVel;
-					fm->setParticleState(i, ParticleState::AnimatedByEmitter);
-					fm->setObjectId(i, m_objectId);
-				}
-			}
-		}
-	}
-	if (t < m_nextEmitTime || t > m_emitEndTime)
-	{
-		return;
-	}
-
-	const Vector3r axisHeight = m_rotation.col(1);
-	const Vector3r axisWidth = m_rotation.col(2);
-	
-	const Real startX = -static_cast<Real>(0.5)*(m_width  - 1)*diam;
-	const Real startZ = -static_cast<Real>(0.5)*(m_height - 1)*diam;
-
-	// t-m_nextEmitTime is the time that has passed between the time the particle has been emitted and the current time step.
-	// timeStepSize is added because emission happens at the end of the time step, but the particles are not animated anymore.
-	const Real dt = t - m_nextEmitTime + timeStepSize;
-
-	const Vector3r velocityOffset = dt * emitVel;
-	const Vector3r offset = m_x + velocityOffset;
-
-	if ((m_model->numActiveParticles() < m_model->numParticles()) ||
-		(reusedParticles.size() > 0))
-	{
-		unsigned int indexNotReuse = m_model->numActiveParticles();
-		for (unsigned int i = 0; i < m_width; i++)
-		{
-			for (unsigned int j = 0; j < m_height; j++)
-			{
-				unsigned int index = 0;
-				bool reused = false;
-				if (indexReuse < reusedParticles.size())
-				{
-					index = reusedParticles[indexReuse];
-					reused = true;
-				}
-				else
-				{
-					index = indexNotReuse;
-				}
-
-				if (index < m_model->numParticles())
-				{
-					m_model->getPosition(index) = (i*diam + startX)*axisWidth + (j*diam + startZ)*axisHeight + offset;
-					m_model->getVelocity(index) = emitVel;
-					m_model->setParticleState(index, ParticleState::AnimatedByEmitter);
-					m_model->setObjectId(index, m_objectId);
-
-					if (reused)
-					{
-						indexReuse++;
-					}
-					else
-					{
-						numEmittedParticles++;
-						indexNotReuse++;
-					}
-					index++;
-				}
-			}
-		}
-
-		if (numEmittedParticles != 0)
-		{
-			m_model->setNumActiveParticles(m_model->numActiveParticles() + numEmittedParticles);
-			sim->emittedParticles(m_model, m_model->numActiveParticles() - numEmittedParticles);
-			sim->getNeighborhoodSearch()->resize_point_set(m_model->getPointSetIndex(), &m_model->getPosition(0)[0], m_model->numActiveParticles());
-		}
-	}
-	else
-	{
-		if (m_model->numActiveParticles() < m_model->numParticles())
-		{
-			unsigned int index = m_model->numActiveParticles();
-			for (unsigned int i = 0; i < m_width; i++)
-			{
-				for (unsigned int j = 0; j < m_height; j++)
-				{
-					if (index < m_model->numParticles())
-					{
-						m_model->getPosition(index) = (i*diam + startX)*axisWidth + (j*diam + startZ)*axisHeight + offset;
-						m_model->getVelocity(index) = emitVel;
-						m_model->setParticleState(index, ParticleState::AnimatedByEmitter);
-						m_model->setObjectId(index, m_objectId);
-						numEmittedParticles++;
-					}
-					index++;
-				}
-			}
-			m_model->setNumActiveParticles(m_model->numActiveParticles() + numEmittedParticles);
-			sim->emittedParticles(m_model, m_model->numActiveParticles() - numEmittedParticles);
-			sim->getNeighborhoodSearch()->resize_point_set(m_model->getPointSetIndex(), &m_model->getPosition(0)[0], m_model->numActiveParticles());
-		}
-	}
-
-	m_nextEmitTime += diam / m_velocity;
-	m_emitCounter++;
+    return getSize(width + extraMargin, height + extraMargin, type);
 }
 
-
-
-void Emitter::emitParticlesCircle(std::vector <unsigned int> &reusedParticles, unsigned int &indexReuse, unsigned int &numEmittedParticles)
+void Emitter::emitParticles(std::vector<unsigned int>& reusedParticles, unsigned int& indexReuse,
+                            unsigned int& numEmittedParticles)
 {
-	TimeManager *tm = TimeManager::getCurrent();
-	const Real t = tm->getTime();
-	const Real timeStepSize = tm->getTimeStepSize();
-	const Vector3r & emitDir = m_rotation.col(0);
-	Simulation *sim = Simulation::getCurrent();
-	const Real particleRadius = sim->getParticleRadius();
-	const Real diam = static_cast<Real>(2.0)*particleRadius;
-	Vector3r emitVel = m_velocity * emitDir;
+    TimeManager* tm = TimeManager::getCurrent();
+    const Real t = tm->getTime();
+    const Real timeStepSize = tm->getTimeStepSize();
+    const Vector3r axisDepth = m_rotation.col(0);
+    const Vector3r axisHeight = m_rotation.col(1);
+    const Vector3r axisWidth = m_rotation.col(2);
+    Vector3r emitVel = m_velocity * axisDepth;
+    Simulation* sim = Simulation::getCurrent();
+    const Real particleRadius = sim->getParticleRadius();
+    const Real particleDiameter = static_cast<Real>(2.0) * particleRadius;
 
-	// shortly before the emitter starts, cleanup the emitter from particles
-	if (t < m_emitStartTime || t > m_emitEndTime)
-		emitVel = emitDir * particleRadius * 10 / 0.25;
+    unsigned int indexNextNewParticle = m_model->numActiveParticles();
 
-	if (t >= m_emitStartTime - 0.25 && t <= m_emitEndTime)
-	{
-		// animate emitted particles		
-		const Vector3r & x0 = m_x;
+    // fill the emitter at the start of the simulation
+    // The emitter is filled starting from the plane the particles leave the emitter.
+    // TODO: maybe this should be done in the constructor or somewhere else?
+    const Vector3r startPos = m_x + m_depth * particleRadius * axisDepth - (m_width - 1) * particleRadius * axisWidth
+        - (m_height - 1) * particleRadius * axisHeight;
+    if (t == 0.0) {
+        for (unsigned int i = 0; i < m_depth; i++) {
+            for (unsigned int j = 0; j < m_width; j++) {
+                for (unsigned int k = 0; k < m_height; k++) {
+                    const Vector3r spawnPos = startPos - i * axisDepth * particleDiameter
+                        + j * axisWidth * particleDiameter + k * axisHeight * particleDiameter;
 
-		const Real animationMarginAhead = sim->getSupportRadius();
-		const Vector3r size = getSize(static_cast<Real>(m_width), static_cast<Real>(m_height), m_type);
-		const Real h = size[0];
- 		const Real r = 0.5f * size[1];
-		const Real r2 = r * r;
-		const Vector3r pos = x0 + 0.5f * animationMarginAhead * emitDir;
+                    // Spawn particles in a grid.
+                    // Skip the particles outside when a cylindrical emitter is used.
+                    if (m_type == 0
+                        || (m_type == 1
+                            && inCylinder(spawnPos, m_x, m_rotation, m_size[0], (m_size[1] * m_size[1]) / 4)))
+                    {
+                        m_model->setPosition(indexNextNewParticle, spawnPos);
+                        m_model->setParticleState(indexNextNewParticle, ParticleState::AnimatedByEmitter);
+                        m_model->setVelocity(indexNextNewParticle, emitVel);
+                        m_model->setObjectId(indexNextNewParticle, m_objectId);
 
+                        indexNextNewParticle++;
+                        numEmittedParticles++;
+                    }
+                }
+            }
+        }
+    }
 
-		const unsigned int nModels = sim->numberOfFluidModels();
-		for (unsigned int m = 0; m < nModels; m++)
-		{
-			FluidModel *fm = sim->getFluidModel(m);
-			const unsigned int numParticles = fm->numActiveParticles();
- 			#pragma omp parallel for schedule(static) default(shared)
- 			for (int i = 0; i < (int)numParticles; i++)
- 			{
- 				Vector3r &xi = fm->getPosition(i);
- 				if (inCylinder(xi, pos, m_rotation, h, r2))
- 				{
- 					fm->getVelocity(i) = emitVel;
- 					fm->getPosition(i) += timeStepSize * emitVel;
- 					fm->setParticleState(i, ParticleState::AnimatedByEmitter);
-					fm->setObjectId(i, m_objectId);
- 				}
- 			}
-		}
- 	}
-	if (t < m_nextEmitTime || t > m_emitEndTime)
-	{
-		return;
-	}
+    if (t >= m_emitStartTime && t < m_emitEndTime) {
+        // emitter is active
+        for (unsigned int i = 0; i < indexNextNewParticle; i++) {
+            const Vector3r tempPos = m_model->getPosition(i);
+            // Check if the particle is inside the emitter.
+            const bool insideEmitter = (m_type == 0 && inBox(tempPos, m_x, m_rotation, 0.5 * m_size))
+                || (m_type == 1 && inCylinder(tempPos, m_x, m_rotation, m_size[0], (m_size[1] * m_size[1]) / 4));
 
-	Vector3r axisHeight = m_rotation.col(1);
-	Vector3r axisWidth = m_rotation.col(2);
+            if (insideEmitter) {
+                // Advect ALL particles inside the emitter.
+                // TODO: Doesn't get all particles within the boundary. Perhaps use getSizeExtraMargin()?
+                m_model->setPosition(i, tempPos + timeStepSize * emitVel);
+                m_model->setVelocity(i, emitVel);
+            }
+            if (!insideEmitter && m_model->getParticleState(i) == ParticleState::AnimatedByEmitter
+                && m_model->getObjectId(i) == m_objectId)
+            {
+                // particle has left the emitter during last step
+                m_model->setParticleState(i, ParticleState::Active);
+                m_model->setObjectId(i, 0);
+                // reuse or spawn a new particle upstream
+                if (indexReuse < reusedParticles.size()) {
+                    // reuse a particle
+                    m_model->setPosition(reusedParticles[indexReuse], tempPos - axisDepth * particleDiameter * m_depth);
+                    m_model->setParticleState(reusedParticles[indexReuse], ParticleState::AnimatedByEmitter);
+                    m_model->setVelocity(reusedParticles[indexReuse], emitVel);
+                    m_model->setObjectId(reusedParticles[indexReuse], m_objectId);
+                    indexReuse++;
+                }
+                else if (m_model->numActiveParticles() < m_model->numParticles()) {
+                    // spawn a new particle
+                    m_model->setPosition(indexNextNewParticle, tempPos - axisDepth * particleDiameter * m_depth);
+                    m_model->setParticleState(indexNextNewParticle, ParticleState::AnimatedByEmitter);
+                    m_model->setVelocity(indexNextNewParticle, emitVel);
+                    m_model->setObjectId(indexNextNewParticle, m_objectId);
 
-	const Real radius = (static_cast<Real>(0.5) * (Real)m_width * diam);
-	const Real radius2 = radius*radius;
+                    indexNextNewParticle++;
+                    numEmittedParticles++;
+                }
+                else {
+                    LOG_INFO << "No particles left for the emitter to reuse or activate!";
+                }
+            }
+        }
+    }
 
-	const Real startX = -static_cast<Real>(0.5)*(m_width - 1)*diam;
-	const Real startZ = -static_cast<Real>(0.5)*(m_width - 1)*diam;
-
-	// t-m_nextEmitTime is the time that has passed between the time the particle has been emitted and the current time step.
-	// timeStepSize is added because emission happens at the end of the time step, but the particles are not animated anymore.
-	const Real dt = t - m_nextEmitTime + timeStepSize;
-	const Vector3r velocity = emitVel;
-	const Vector3r velocityOffset = dt * velocity;
-	const Vector3r offset = m_x + velocityOffset;
-
-	if ((m_model->numActiveParticles() < m_model->numParticles()) ||
-		(reusedParticles.size() > 0))
-	{
-		unsigned int indexNotReuse = m_model->numActiveParticles();
-		for (unsigned int i = 0; i < m_width; i++)
-		{
-			for (unsigned int j = 0; j < m_width; j++)
-			{
-				const Real x = (i*diam + startX);
-				const Real y = (j*diam + startZ);
-
-				unsigned int index = 0;
-				bool reused = false;
-				if (indexReuse < reusedParticles.size())
-				{
-					index = reusedParticles[indexReuse];
-					reused = true;
-				}
-				else
-				{
-					index = indexNotReuse;
-				}
-
-				if ((index < m_model->numParticles()) && (x*x + y*y <= radius2))
-				{
-					m_model->getPosition(index) = x*axisWidth + y*axisHeight + offset;
-					m_model->getVelocity(index) = velocity;
-					m_model->setParticleState(index, ParticleState::AnimatedByEmitter);
-					m_model->setObjectId(index, m_objectId);
-
-					if (reused)
-					{
-						indexReuse++;
-					}
-					else
-					{
-						numEmittedParticles++;
-						indexNotReuse++;
-					}
-					index++;
-				}
-			}
-		}
-
-		if (numEmittedParticles != 0)
-		{
-			m_model->setNumActiveParticles(m_model->numActiveParticles() + numEmittedParticles);
-			sim->emittedParticles(m_model, m_model->numActiveParticles() - numEmittedParticles);
-			sim->getNeighborhoodSearch()->resize_point_set(m_model->getPointSetIndex(), &m_model->getPosition(0)[0], m_model->numActiveParticles());
-		}
-	}
-	else
-	{
-		if (m_model->numActiveParticles() < m_model->numParticles())
-		{
-			unsigned int index = m_model->numActiveParticles();
-			for (unsigned int i = 0; i < m_width; i++)
-			{
-				for (unsigned int j = 0; j < m_width; j++)
-				{
-					const Real x = (i*diam + startX);
-					const Real y = (j*diam + startZ);
-					if ((index < m_model->numParticles()) && (x*x + y*y <= radius2))
-					{
-						m_model->getPosition(index) = x*axisWidth + y*axisHeight + offset;
-						m_model->getVelocity(index) = velocity;
-						m_model->setParticleState(index, ParticleState::AnimatedByEmitter);
-						m_model->setObjectId(index, m_objectId);
-						numEmittedParticles++;
-						index++;
-					}
-				}
-			}
-			m_model->setNumActiveParticles(m_model->numActiveParticles() + numEmittedParticles);
-			sim->emittedParticles(m_model, m_model->numActiveParticles() - numEmittedParticles);
-			sim->getNeighborhoodSearch()->resize_point_set(m_model->getPointSetIndex(), &m_model->getPosition(0)[0], m_model->numActiveParticles());
-		}
-	}
-
-	m_nextEmitTime += diam / m_velocity;
-	m_emitCounter++;
+    m_model->setNumActiveParticles(m_model->numActiveParticles() + numEmittedParticles);
+    sim->emittedParticles(m_model, m_model->numActiveParticles() - numEmittedParticles);
+    sim->getNeighborhoodSearch()->resize_point_set(m_model->getPointSetIndex(), &m_model->getPosition(0)[0],
+                                                   m_model->numActiveParticles());
 }
 
-void Emitter::step(std::vector <unsigned int> &reusedParticles, unsigned int &indexReuse, unsigned int &numEmittedParticles)
+void Emitter::step(std::vector<unsigned int>& reusedParticles, unsigned int& indexReuse,
+                   unsigned int& numEmittedParticles)
 {
-	if (m_type == 1)
-		emitParticlesCircle(reusedParticles, indexReuse, numEmittedParticles);
-	else
-		emitParticles(reusedParticles, indexReuse, numEmittedParticles);
+    emitParticles(reusedParticles, indexReuse, numEmittedParticles);
 }
 
-void SPH::Emitter::saveState(BinaryFileWriter &binWriter)
-{
-	binWriter.write(m_nextEmitTime);
-	binWriter.write(m_emitCounter);
-}
+void SPH::Emitter::saveState(BinaryFileWriter& binWriter) { binWriter.write(m_emitCounter); }
 
-void SPH::Emitter::loadState(BinaryFileReader &binReader)
-{
-	binReader.read(m_nextEmitTime);
-	binReader.read(m_emitCounter);
-}
-
+void SPH::Emitter::loadState(BinaryFileReader& binReader) { binReader.read(m_emitCounter); }

--- a/SPlisHSPlasH/Emitter.h
+++ b/SPlisHSPlasH/Emitter.h
@@ -15,22 +15,25 @@ namespace SPH
 				const unsigned int width, const unsigned int height,
 				const Vector3r &pos, const Matrix3r & rotation,
 				const Real velocity,
-				const unsigned int type = 0);
+				const unsigned int type = 0,
+				const bool useBoundary = false);
 			virtual ~Emitter();
 
 		protected:
 			FluidModel *m_model;
 			unsigned int m_width; 
 			unsigned int m_height;
+			unsigned int m_depth;
+    		Vector3r m_size{0, 0, 0};
 			Vector3r m_x;
 			Matrix3r m_rotation;
 			Real m_velocity;
 			unsigned int m_type;
-			Real m_nextEmitTime;
-			Real m_emitStartTime;
-			Real m_emitEndTime;
-			unsigned int m_emitCounter;
+			Real m_emitStartTime{0};
+			Real m_emitEndTime{std::numeric_limits<Real>::max()};
+			unsigned int m_emitCounter{0};
 			unsigned int m_objectId;
+			bool m_useBoundary;
 
 			FORCE_INLINE bool inBox(const Vector3r &x, const Vector3r &xBox, const Matrix3r &rotBox, const Vector3r &scaleBox)
 			{
@@ -53,12 +56,11 @@ namespace SPH
 
 		public:
 			void emitParticles(std::vector <unsigned int> &reusedParticles, unsigned int &indexReuse, unsigned int &numEmittedParticles);
-			void emitParticlesCircle(std::vector <unsigned int> &reusedParticles, unsigned int &indexReuse, unsigned int &numEmittedParticles);
-			Real getNextEmitTime() const { return m_nextEmitTime; }
-			void setNextEmitTime(Real val) { m_nextEmitTime = val; }
-			void setEmitStartTime(Real val) { m_emitStartTime = val; setNextEmitTime(val); }
+			void setEmitStartTime(Real val) { m_emitStartTime = val; }
 			void setEmitEndTime(Real val) { m_emitEndTime = val; }
+			static int getDepth();
 			static Vector3r getSize(const Real width, const Real height, const int type);
+			static Vector3r getSizeExtraMargin(const Real width, const Real height, const int type);
 
 			void step(std::vector <unsigned int> &reusedParticles, unsigned int &indexReuse, unsigned int &numEmittedParticles);
 			virtual void reset();

--- a/SPlisHSPlasH/Emitter.h
+++ b/SPlisHSPlasH/Emitter.h
@@ -24,7 +24,7 @@ namespace SPH
 			FluidModel *m_model;
 			unsigned int m_width; 
 			unsigned int m_height;
-			unsigned int m_depth;
+			static const unsigned int m_depth{4};
     		Vector3r m_size{0, 0, 0};
 			Vector3r m_x;
 			Matrix3r m_rotation;
@@ -60,7 +60,6 @@ namespace SPH
 			void emitParticles(std::vector <unsigned int> &reusedParticles, unsigned int &indexReuse, unsigned int &numEmittedParticles);
 			void setEmitStartTime(Real val) { m_emitStartTime = val; }
 			void setEmitEndTime(Real val) { m_emitEndTime = val; }
-			static int getDepth();
 			static Vector3r getSize(const Real width, const Real height, const int type);
 			static Vector3r getSizeExtraMargin(const Real width, const Real height, const int type);
 

--- a/SPlisHSPlasH/Emitter.h
+++ b/SPlisHSPlasH/Emitter.h
@@ -16,7 +16,8 @@ namespace SPH
 				const Vector3r &pos, const Matrix3r & rotation,
 				const Real velocity,
 				const unsigned int type = 0,
-				const bool useBoundary = false);
+				const bool useBoundary = false,
+				const unsigned int velocityProfile = 0);
 			virtual ~Emitter();
 
 		protected:
@@ -34,6 +35,7 @@ namespace SPH
 			unsigned int m_emitCounter{0};
 			unsigned int m_objectId;
 			bool m_useBoundary;
+			unsigned int m_velocityProfile;// 0: constant, 1: linear, 2: quadratic
 
 			FORCE_INLINE bool inBox(const Vector3r &x, const Vector3r &xBox, const Matrix3r &rotBox, const Vector3r &scaleBox)
 			{

--- a/SPlisHSPlasH/EmitterSystem.cpp
+++ b/SPlisHSPlasH/EmitterSystem.cpp
@@ -82,18 +82,18 @@ void EmitterSystem::reset()
 	}
 }
 
-void EmitterSystem::addEmitter(const unsigned int width, const unsigned int height,
-	const Vector3r &pos, const Matrix3r & rotation,
-	const Real velocity,
-	const unsigned int type,
-	const bool useBoundary)
+void EmitterSystem::addEmitter(const unsigned int width, const unsigned int height, const Vector3r& pos,
+                               const Matrix3r& rotation, const Real velocity, const unsigned int type,
+                               const bool useBoundary, const unsigned int velocityProfile)
 {
-	m_emitters.push_back(new Emitter(m_model,
+	m_emitters.push_back(
+        new Emitter(m_model,
 		width, height,
 		pos, rotation,
 		velocity,
 		type,
-		useBoundary));
+		useBoundary,
+		velocityProfile));
 }
 
 void EmitterSystem::enableReuseParticles(const Vector3r &boxMin /*= Vector3r(-1, -1, -1)*/, const Vector3r &boxMax /*= Vector3r(1, 1, 1)*/)

--- a/SPlisHSPlasH/EmitterSystem.cpp
+++ b/SPlisHSPlasH/EmitterSystem.cpp
@@ -59,17 +59,6 @@ void EmitterSystem::step()
 	// reset particle state
 	Simulation *sim = Simulation::getCurrent();
 	const unsigned int nModels = sim->numberOfFluidModels();
-	for (unsigned int m = 0; m < nModels; m++)
-	{
-		FluidModel *fm = sim->getFluidModel(m);
-		const unsigned int numParticles = fm->numActiveParticles();
-		#pragma omp parallel for schedule(static) default(shared)
-		for (int i = 0; i < (int)numParticles; i++)
-		{
-			if (fm->getParticleState(i) == ParticleState::AnimatedByEmitter)
-				fm->setParticleState(i, ParticleState::Active);
-		}
-	}
 
 	reuseParticles();
 	unsigned int indexReuse = 0;	
@@ -96,13 +85,15 @@ void EmitterSystem::reset()
 void EmitterSystem::addEmitter(const unsigned int width, const unsigned int height,
 	const Vector3r &pos, const Matrix3r & rotation,
 	const Real velocity,
-	const unsigned int type)
+	const unsigned int type,
+	const bool useBoundary)
 {
 	m_emitters.push_back(new Emitter(m_model,
 		width, height,
 		pos, rotation,
 		velocity,
-		type));
+		type,
+		useBoundary));
 }
 
 void EmitterSystem::enableReuseParticles(const Vector3r &boxMin /*= Vector3r(-1, -1, -1)*/, const Vector3r &boxMax /*= Vector3r(1, 1, 1)*/)

--- a/SPlisHSPlasH/EmitterSystem.h
+++ b/SPlisHSPlasH/EmitterSystem.h
@@ -34,8 +34,8 @@ namespace SPH
 			void disableReuseParticles();
 			void addEmitter(const unsigned int width, const unsigned int height,
 				const Vector3r &pos, const Matrix3r & rotation,
-				const Real velocity,
-				const unsigned int type);
+				const Real velocity,const unsigned int type,
+				const bool useBoundary = false);
 			unsigned int numEmitters() const { return static_cast<unsigned int>(m_emitters.size()); }
 			std::vector<Emitter*> &getEmitters() { return m_emitters; }
 

--- a/SPlisHSPlasH/EmitterSystem.h
+++ b/SPlisHSPlasH/EmitterSystem.h
@@ -35,7 +35,7 @@ namespace SPH
 			void addEmitter(const unsigned int width, const unsigned int height,
 				const Vector3r &pos, const Matrix3r & rotation,
 				const Real velocity,const unsigned int type,
-				const bool useBoundary = false);
+				const bool useBoundary = false, const unsigned int velocityProfile = 0);
 			unsigned int numEmitters() const { return static_cast<unsigned int>(m_emitters.size()); }
 			std::vector<Emitter*> &getEmitters() { return m_emitters; }
 

--- a/SPlisHSPlasH/Utilities/SceneParameterObjects.cpp
+++ b/SPlisHSPlasH/Utilities/SceneParameterObjects.cpp
@@ -138,6 +138,7 @@ int EmitterParameterObject::EMITTER_ROTANGLE = -1;
 int EmitterParameterObject::EMITTER_STARTTIME = -1;
 int EmitterParameterObject::EMITTER_ENDTIME = -1;
 int EmitterParameterObject::EMITTER_TYPE = -1;
+int EmitterParameterObject::EMITTER_USEBOUNDARY = -1;
 
 void EmitterParameterObject::initParameters()
 {
@@ -180,6 +181,10 @@ void EmitterParameterObject::initParameters()
 	EMITTER_TYPE = createNumericParameter<unsigned int>("type", "Emitter type", &type);
 	setGroup(EMITTER_TYPE, "Emitter");
 	setDescription(EMITTER_TYPE, "Defines the shape of the emitter: 0: box, 1: circle.");
+
+	EMITTER_USEBOUNDARY = createBoolParameter("useBoundary", "Use Boundary", &useBoundary);
+    setGroup(EMITTER_USEBOUNDARY, "Emitter");
+    setDescription(EMITTER_USEBOUNDARY, "Creates a boundary model around the emitter if defined");
 }
 
 

--- a/SPlisHSPlasH/Utilities/SceneParameterObjects.cpp
+++ b/SPlisHSPlasH/Utilities/SceneParameterObjects.cpp
@@ -139,6 +139,7 @@ int EmitterParameterObject::EMITTER_STARTTIME = -1;
 int EmitterParameterObject::EMITTER_ENDTIME = -1;
 int EmitterParameterObject::EMITTER_TYPE = -1;
 int EmitterParameterObject::EMITTER_USEBOUNDARY = -1;
+int EmitterParameterObject::EMITTER_VELOCITYPROFILE = -1;
 
 void EmitterParameterObject::initParameters()
 {
@@ -185,6 +186,11 @@ void EmitterParameterObject::initParameters()
 	EMITTER_USEBOUNDARY = createBoolParameter("useBoundary", "Use Boundary", &useBoundary);
     setGroup(EMITTER_USEBOUNDARY, "Emitter");
     setDescription(EMITTER_USEBOUNDARY, "Creates a boundary model around the emitter if defined");
+
+    EMITTER_VELOCITYPROFILE =
+        createNumericParameter<unsigned int>("velocityProfile", "Velocity Profile", &velocityProfile);
+    setGroup(EMITTER_VELOCITYPROFILE, "Emitter");
+    setDescription(EMITTER_VELOCITYPROFILE, "Defines the velocity profile of the emitter.");
 }
 
 

--- a/SPlisHSPlasH/Utilities/SceneParameterObjects.h
+++ b/SPlisHSPlasH/Utilities/SceneParameterObjects.h
@@ -145,6 +145,7 @@ namespace Utilities
 		Real emitEndTime;
 		unsigned int type;	// type: 0 = rectangular, 1 = circle
 		bool useBoundary;
+		unsigned int velocityProfile;
 
 		EmitterParameterObject()
 		{
@@ -160,10 +161,11 @@ namespace Utilities
 			emitEndTime = std::numeric_limits<Real>::max();
 			type = 0;
 			useBoundary = false;
+			velocityProfile = 0;
 		}
 
 		EmitterParameterObject(std::string id_, unsigned int width_, unsigned int height_, Vector3r x_, Real velocity_, Vector3r axis_, 
-							Real angle_, Real emitStartTime_, Real emitEndTime_, unsigned int type_, bool useBoundary_)
+							Real angle_, Real emitStartTime_, Real emitEndTime_, unsigned int type_, bool useBoundary_, unsigned int velocityProfile_)
 		{
 			id = id_;
 			width = width_;
@@ -176,6 +178,7 @@ namespace Utilities
 			emitEndTime = emitEndTime_;
 			type = type_;
 			useBoundary = useBoundary_;
+			velocityProfile = velocityProfile_;
 		}
 
 		static int EMITTER_ID;
@@ -189,6 +192,7 @@ namespace Utilities
 		static int EMITTER_ENDTIME;
 		static int EMITTER_TYPE;
 		static int EMITTER_USEBOUNDARY;
+		static int EMITTER_VELOCITYPROFILE;
 
 		virtual void initParameters();
 	};

--- a/SPlisHSPlasH/Utilities/SceneParameterObjects.h
+++ b/SPlisHSPlasH/Utilities/SceneParameterObjects.h
@@ -144,6 +144,7 @@ namespace Utilities
 		Real emitStartTime;
 		Real emitEndTime;
 		unsigned int type;	// type: 0 = rectangular, 1 = circle
+		bool useBoundary;
 
 		EmitterParameterObject()
 		{
@@ -158,10 +159,11 @@ namespace Utilities
 			emitStartTime = 0.0;
 			emitEndTime = std::numeric_limits<Real>::max();
 			type = 0;
+			useBoundary = false;
 		}
 
 		EmitterParameterObject(std::string id_, unsigned int width_, unsigned int height_, Vector3r x_, Real velocity_, Vector3r axis_, 
-							Real angle_, Real emitStartTime_, Real emitEndTime_, unsigned int type_)
+							Real angle_, Real emitStartTime_, Real emitEndTime_, unsigned int type_, bool useBoundary_)
 		{
 			id = id_;
 			width = width_;
@@ -173,6 +175,7 @@ namespace Utilities
 			emitStartTime = emitStartTime_;
 			emitEndTime = emitEndTime_;
 			type = type_;
+			useBoundary = useBoundary_;
 		}
 
 		static int EMITTER_ID;
@@ -185,6 +188,7 @@ namespace Utilities
 		static int EMITTER_STARTTIME;
 		static int EMITTER_ENDTIME;
 		static int EMITTER_TYPE;
+		static int EMITTER_USEBOUNDARY;
 
 		virtual void initParameters();
 	};

--- a/Simulator/PositionBasedDynamicsWrapper/PBDBoundarySimulator.cpp
+++ b/Simulator/PositionBasedDynamicsWrapper/PBDBoundarySimulator.cpp
@@ -70,7 +70,7 @@ void PBDBoundarySimulator::initBoundaryData()
 		PBDWrapper::RBData rb;
 		rb.x = ed->x;
 		rb.R = AngleAxisr(ed->angle, ed->axis).toRotationMatrix();
-		rb.scale = Emitter::getSize(static_cast<Real>(ed->width), static_cast<Real>(ed->height), ed->type);
+        rb.scale = Emitter::getSizeExtraMargin(static_cast<Real>(ed->width), static_cast<Real>(ed->height), ed->type);
 		rb.restitution = 0.6;
 		rb.friction = 0.1;
 		if (ed->type == 0)

--- a/Simulator/SimulatorBase.cpp
+++ b/Simulator/SimulatorBase.cpp
@@ -1317,7 +1317,7 @@ void SimulatorBase::createEmitters()
 			}
 			Matrix3r rot = AngleAxisr(ed->angle, ed->axis.normalized()).toRotationMatrix();
 			model->getEmitterSystem()->addEmitter(ed->width, ed->height, ed->x, rot, ed->velocity, ed->type,
-                                                  ed->useBoundary);
+                                                  ed->useBoundary, ed->velocityProfile);
 
 			Emitter* emitter = model->getEmitterSystem()->getEmitters().back();
 			if (ed->useBoundary) {

--- a/Simulator/SimulatorBase.cpp
+++ b/Simulator/SimulatorBase.cpp
@@ -1315,39 +1315,38 @@ void SimulatorBase::createEmitters()
 				ed->width = 1;
 				ed->type = 0;
 			}
-			Matrix3r rot = AngleAxisr(ed->angle, ed->axis).toRotationMatrix();
-			model->getEmitterSystem()->addEmitter(
-				ed->width, ed->height,
-				ed->x, rot,
-				ed->velocity,
-				ed->type);
+			Matrix3r rot = AngleAxisr(ed->angle, ed->axis.normalized()).toRotationMatrix();
+			model->getEmitterSystem()->addEmitter(ed->width, ed->height, ed->x, rot, ed->velocity, ed->type,
+                                                  ed->useBoundary);
 
-			// Generate boundary geometry around emitters
-			Emitter *emitter = model->getEmitterSystem()->getEmitters().back();
-			BoundaryParameterObject *emitterBoundary = new BoundaryParameterObject();
-			emitterBoundary->dynamic = false;
-			emitterBoundary->isWall = false;
-			emitterBoundary->color = { 0.2f, 0.2f, 0.2f, 1.0f };
-			emitterBoundary->axis = ed->axis;
-			emitterBoundary->angle = ed->angle;
-			const Real supportRadius = sim->getSupportRadius();
-			const Vector3r & emitDir = rot.col(0);
-			emitterBoundary->scale = Emitter::getSize(static_cast<Real>(ed->width), static_cast<Real>(ed->height), ed->type);
-			const Vector3r pos = ed->x;
-			emitterBoundary->translation = pos;
-			emitterBoundary->samplesFile = "";
-			emitterBoundary->mapInvert = false;
-			emitterBoundary->mapResolution = Eigen::Matrix<unsigned int, 3, 1, Eigen::DontAlign>(20, 20, 20);
-			emitterBoundary->mapThickness = 0.0;
+			Emitter* emitter = model->getEmitterSystem()->getEmitters().back();
+			if (ed->useBoundary) {
+				// Generate boundary geometry around emitters
+				BoundaryParameterObject* emitterBoundary = new BoundaryParameterObject();
+				emitterBoundary->dynamic = false;
+				emitterBoundary->isWall = false;
+				emitterBoundary->color = {0.2f, 0.2f, 0.2f, 1.0f};
+				emitterBoundary->axis = ed->axis;
+				emitterBoundary->angle = ed->angle;
+				const Real supportRadius = sim->getSupportRadius();
+				const Vector3r& emitDir = rot.col(0);
+				emitterBoundary->scale = Emitter::getSizeExtraMargin(static_cast<Real>(ed->width), static_cast<Real>(ed->height), ed->type);
+				const Vector3r pos = ed->x;
+				emitterBoundary->translation = pos;
+				emitterBoundary->samplesFile = "";
+				emitterBoundary->mapInvert = false;
+				emitterBoundary->mapResolution = Eigen::Matrix<unsigned int, 3, 1, Eigen::DontAlign>(20, 20, 20);
+				emitterBoundary->mapThickness = 0.0;
 
-			if (sim->is2DSimulation())
-				emitterBoundary->scale[2] = 2 * supportRadius;
+				if (sim->is2DSimulation())
+					emitterBoundary->scale[2] = 2 * supportRadius;
 
-			if (ed->type == 0)
-				emitterBoundary->meshFile = FileSystem::normalizePath(getExePath() + "/resources/emitter_boundary/EmitterBox.obj");
-			else if (ed->type == 1)
-				emitterBoundary->meshFile = FileSystem::normalizePath(getExePath() + "/resources/emitter_boundary/EmitterCylinder.obj");
-			scene.boundaryModels.push_back(emitterBoundary);
+				if (ed->type == 0)
+					emitterBoundary->meshFile = FileSystem::normalizePath(getExePath() + "/resources/emitter_boundary/EmitterBox.obj");
+				else if (ed->type == 1)
+					emitterBoundary->meshFile = FileSystem::normalizePath(getExePath() + "/resources/emitter_boundary/EmitterCylinder.obj");
+				scene.boundaryModels.push_back(emitterBoundary);
+			}
 			
 			// reuse particles if they are outside of a bounding box
 			bool emitterReuseParticles = false;

--- a/pySPlisHSPlasH/EmitterModule.cpp
+++ b/pySPlisHSPlasH/EmitterModule.cpp
@@ -28,9 +28,6 @@ void EmitterModule(py::module m_sub){
                 return SPH::Emitter(model, width, height, pos, rotation, velocity, type);
             }))
             .def("emitParticles", &SPH::Emitter::emitParticles)
-            .def("emitParticlesCircle", &SPH::Emitter::emitParticlesCircle)
-            .def("getNextEmitTime", &SPH::Emitter::getNextEmitTime)
-            .def("setNextEmitTime", &SPH::Emitter::setNextEmitTime)
             .def("setEmitStartTime", &SPH::Emitter::setEmitStartTime)
             .def("setEmitEndTime", &SPH::Emitter::setEmitEndTime)
             .def("getPosition", &SPH::Emitter::getPosition)

--- a/pySPlisHSPlasH/UtilitiesModule.cpp
+++ b/pySPlisHSPlasH/UtilitiesModule.cpp
@@ -339,10 +339,11 @@ void UtilitiesModule(py::module m) {
 
     py::class_<Utilities::EmitterParameterObject, GenParam::ParameterObject>(m_sub_sub, "EmitterData")
         .def(py::init<>())
-        .def(py::init<std::string, unsigned int, unsigned int, Vector3r, Real, Vector3r, Real, Real, Real, unsigned int, bool>(),
+        .def(py::init<std::string, unsigned int, unsigned int, Vector3r, Real, Vector3r, Real, Real, Real, unsigned int, bool, unsigned int>(),
                 "id"_a="Fluid", "width"_a=5, "height"_a=5, "x"_a=Vector3r::Zero(),
                 "velocity"_a=1, "axis"_a = Vector3r(1, 0, 0), "angle"_a = 0.0, "emitStartTime"_a=0,
-                "emitEndTime"_a=std::numeric_limits<Real>::max(), "type"_a=0, "useBoundary"_a = false)
+                "emitEndTime"_a=std::numeric_limits<Real>::max(), "type"_a=0, "useBoundary"_a = false,
+                "velocityProfile"_a = 0)
         .def_readwrite("id", &Utilities::EmitterParameterObject::id)
         .def_readwrite("width", &Utilities::EmitterParameterObject::width)
         .def_readwrite("height", &Utilities::EmitterParameterObject::height)

--- a/pySPlisHSPlasH/UtilitiesModule.cpp
+++ b/pySPlisHSPlasH/UtilitiesModule.cpp
@@ -339,10 +339,10 @@ void UtilitiesModule(py::module m) {
 
     py::class_<Utilities::EmitterParameterObject, GenParam::ParameterObject>(m_sub_sub, "EmitterData")
         .def(py::init<>())
-        .def(py::init<std::string, unsigned int, unsigned int, Vector3r, Real, Vector3r, Real, Real, Real, unsigned int>(),
+        .def(py::init<std::string, unsigned int, unsigned int, Vector3r, Real, Vector3r, Real, Real, Real, unsigned int, bool>(),
                 "id"_a="Fluid", "width"_a=5, "height"_a=5, "x"_a=Vector3r::Zero(),
                 "velocity"_a=1, "axis"_a = Vector3r(1, 0, 0), "angle"_a = 0.0, "emitStartTime"_a=0,
-                "emitEndTime"_a=std::numeric_limits<Real>::max(), "type"_a=0)
+                "emitEndTime"_a=std::numeric_limits<Real>::max(), "type"_a=0, "useBoundary"_a = false)
         .def_readwrite("id", &Utilities::EmitterParameterObject::id)
         .def_readwrite("width", &Utilities::EmitterParameterObject::width)
         .def_readwrite("height", &Utilities::EmitterParameterObject::height)
@@ -352,7 +352,8 @@ void UtilitiesModule(py::module m) {
         .def_readwrite("angle", &Utilities::EmitterParameterObject::angle)
         .def_readwrite("emitStartTime", &Utilities::EmitterParameterObject::emitStartTime)
         .def_readwrite("emitEndTime", &Utilities::EmitterParameterObject::emitEndTime)
-        .def_readwrite("type", &Utilities::EmitterParameterObject::type);
+        .def_readwrite("type", &Utilities::EmitterParameterObject::type)
+        .def_readwrite("useBoundary", &Utilities::EmitterParameterObject::useBoundary);
 
     py::class_<Utilities::AnimationFieldParameterObject, GenParam::ParameterObject>(m_sub_sub, "AnimationFieldData")
         .def(py::init<>())


### PR DESCRIPTION
I discovered that the current implementation of emitters does not allow for changes in the emit-velocity. It works somewhat for small changes, but after setting the velocity to zero, for instance, the emitter won't wake up again. I mentioned this in #309, although I didn't fully understand it back then.

This PR changes the emitter concept to avoid using the calculation of future activity based on the current velocity. The emitter is simply filled at the beginning of the simulation and the particles are advected in every step as dictated by the current velocity. I also shortened the implementation by not repeating the code for square and circular emitters.

Additionally, I made the boundary surrounding the emitter optional. This is already the case elsewhere but was missing in this repo.

Lastly, I added velocity profiles for **circular** emitters: You can now select an integer as an exponent and the emitter will get a corresponding velocity profile with the max velocity in the center. 0 will result in a constant velocity across the emitter, 1 in a linear distribution, 2 in a quadratic and so on. The volume flow is always kept the same as it would be for a constant velocity. The max velocity will therefore be a bit higher than the specified velocity.

I am looking forward to your feedback!