### PR TITLE
Fix frozen particles affected by gravity when using Projective Fluids

### DIFF
--- a/SPlisHSPlasH/PF/TimeStepPF.cpp
+++ b/SPlisHSPlasH/PF/TimeStepPF.cpp
@@ -183,9 +183,16 @@ void TimeStepPF::initialGuessForPositions(const unsigned int fluidModelIndex)
 	for (int i = 0; i < (int)numParticles; i++)
 	{
 		m_simulationData.setOldPosition(fluidModelIndex, i, model->getPosition(i));
-		const auto newPos = (model->getPosition(i) + h * model->getVelocity(i) + (h * h) * model->getAcceleration(i)).eval();
-		model->setPosition(i, newPos);
-		m_simulationData.setS(fluidModelIndex, i, newPos);
+		if (model->getParticleState(i) == ParticleState::Active)
+		{
+			const auto newPos = (model->getPosition(i) + h * model->getVelocity(i) + (h * h) * model->getAcceleration(i)).eval();
+			model->setPosition(i, newPos);
+			m_simulationData.setS(fluidModelIndex, i, newPos);
+		}
+		else
+		{
+			m_simulationData.setS(fluidModelIndex, i, model->getPosition(i));
+		}
 	}
 }
 

--- a/SPlisHSPlasH/TimeStep.cpp
+++ b/SPlisHSPlasH/TimeStep.cpp
@@ -41,10 +41,14 @@ void TimeStep::clearAccelerations(const unsigned int fluidModelIndex)
 	for (unsigned int i=0; i < count; i++)
 	{
 		// Clear accelerations of dynamic particles
+		Vector3r& a = model->getAcceleration(i);
 		if (model->getMass(i) != 0.0 && model->getParticleState(i) == ParticleState::Active)
 		{
-			Vector3r &a = model->getAcceleration(i);
 			a = grav;
+		}
+		else
+		{
+			a.setZero();
 		}
 	}
 }

--- a/SPlisHSPlasH/TimeStep.cpp
+++ b/SPlisHSPlasH/TimeStep.cpp
@@ -41,7 +41,7 @@ void TimeStep::clearAccelerations(const unsigned int fluidModelIndex)
 	for (unsigned int i=0; i < count; i++)
 	{
 		// Clear accelerations of dynamic particles
-		if (model->getMass(i) != 0.0)
+		if (model->getMass(i) != 0.0 && model->getParticleState(i) == ParticleState::Active)
 		{
 			Vector3r &a = model->getAcceleration(i);
 			a = grav;


### PR DESCRIPTION
I observed frozen particles drifting along the gravity vector instead of being fixed in space. The additional check in `TimeStep::clearAccelerations` ensures, gravity is only applied to active particles and fixes the issue.

I have only observed the bug using the Projective Fluids scheme, which I find surprising, as the other schemes seem to rely on the function as well. However, that might just be my lack of understanding.

~~The function name also seems to imply to me that perhaps the accelerations should be set to zero, if the condition is false. But this seemed to make no difference to the result.~~ The acceleration for non-active particles is set to zero, otherwise, particles in emitters move in unexpected ways when using projective fluids.